### PR TITLE
Fix logging argument quoting

### DIFF
--- a/lib/log/log.sh
+++ b/lib/log/log.sh
@@ -8,21 +8,21 @@ function log::info() {
     if [ ${LOG_VERBOSE} -eq 0 ]; then
         return 0
     fi
-    color::white "$(date +%Y-%m-%dT%H:%M:%S) INFO ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}] $@"
+    color::white "$(date +%Y-%m-%dT%H:%M:%S) INFO ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}]" "$@"
     return 0
 }
 
 function log::warn() {
-    color::yellow "$(date +%Y-%m-%dT%H:%M:%S) WARN ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}] $@"
+    color::yellow "$(date +%Y-%m-%dT%H:%M:%S) WARN ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}]" "$@"
     return 0
 }
 
 function log::error() {
-    color::red "$(date +%Y-%m-%dT%H:%M:%S) ERROR ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}] $@"
+    color::red "$(date +%Y-%m-%dT%H:%M:%S) ERROR ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}]" "$@"
     return 1
 }
 
 function log::notice() {
-    color::blue "$(date +%Y-%m-%dT%H:%M:%S) NOTICE ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}] $@"
+    color::blue "$(date +%Y-%m-%dT%H:%M:%S) NOTICE ${BASH_SOURCE[1]}:${BASH_LINENO[0]} callers:[${FUNCNAME[@]:1}]" "$@"
     return 0
 }


### PR DESCRIPTION
## Summary
- quote log message arguments before passing them to the color helpers so multi-word messages stay intact

## Testing
- bash tools.sh

------
https://chatgpt.com/codex/tasks/task_e_68da2101f7ac8333a137cdae88b51792