### PR TITLE
Add CLI help handling to tools script

### DIFF
--- a/tools.sh
+++ b/tools.sh
@@ -4,7 +4,40 @@ base=$(cd $(dirname ${BASH_SOURCE[0]}); pwd)
 source "${base}/lib/source_all.sh"
 unset base
 
-log::info "test log content"
-log::warn "test log content"
-log::error "test log content"
-log::notice "test log content"
+function help() {
+    local script_name
+    script_name=$(basename "${BASH_SOURCE[0]}")
+    cat <<USAGE
+Usage: ${script_name} <command>
+
+Commands:
+  demo        Show sample log outputs.
+  help        Show this message.
+USAGE
+}
+
+function demo() {
+    log::info "test log content"
+    log::warn "test log content"
+    log::error "test log content"
+    log::notice "test log content"
+}
+
+if [ $# -eq 0 ]; then
+    help
+    exit 0
+fi
+
+case "$1" in
+    demo)
+        demo
+        ;;
+    help|-h|--help)
+        help
+        ;;
+    *)
+        log::error "unknown command: $1"
+        help
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- add a help function to describe the available commands
- run the existing log demo via a new `demo` command and call help when no arguments are provided

## Testing
- bash tools.sh
- bash tools.sh demo

------
https://chatgpt.com/codex/tasks/task_e_68da1f94bd4c8333af2566c820c0de1c